### PR TITLE
Add `chime` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,31 +142,31 @@ raise ValueError("I'm going to make some noise")
 You can run `chime` from the command-line:
 
 ```sh
-$ python -m chime
+$ chime
 ```
 
 By default, this will play the success sound. You can also choose which sound to play, like so:
 
 ```sh
-$ python -m chime info
+$ chime info
 ```
 
 You can also choose which theme to use:
 
 ```sh
-$ python -m chime info --theme zelda
+$ chime info --theme zelda
 ```
 
 If you're using bash, then you can use `chime` to notify you when a program finishes:
 
 ```sh
-$ echo "Hello world!"; python -m chime
+$ echo "Hello world!"; chime
 ```
 
 This will play the sound regardless of the fact that the first command succeeded or not. If you're running on Windows, then you can run the following equivalent:
 
 ```sh
-> echo "Hello world!" & python -m chime
+> echo "Hello world!" & chime
 ```
 
 ## Platform support

--- a/chime.py
+++ b/chime.py
@@ -254,8 +254,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('event', nargs='?', default='success',
                         help='either one of {success, warning, error, info}')
-    parser.add_argument('--theme',
-                        help=f'either one of {{{", ".join(themes())}}}')
+    parser.add_argument('--theme', help=f'either one of {{{", ".join(themes())}}}')
     args = parser.parse_args()
     if args.theme:
         theme(args.theme)

--- a/chime.py
+++ b/chime.py
@@ -250,7 +250,7 @@ if IPYTHON_INSTALLED:
 
 
 def main():
-    """Command-line linterface."""
+    """Command-line interface."""
     parser = argparse.ArgumentParser()
     parser.add_argument('event', nargs='?', default='success',
                         help='either one of {success, warning, error, info}')

--- a/chime.py
+++ b/chime.py
@@ -249,15 +249,18 @@ if IPYTHON_INSTALLED:
         ipython.register_magics(ChimeMagics)
 
 
-if __name__ == '__main__':
-
+def main():
+    """Command-line linterface."""
     parser = argparse.ArgumentParser()
     parser.add_argument('event', nargs='?', default='success',
                         help='either one of {success, warning, error, info}')
-    parser.add_argument('--theme', help=f'either one of {{{", ".join(themes())}}}')
+    parser.add_argument('--theme',
+                        help=f'either one of {{{", ".join(themes())}}}')
     args = parser.parse_args()
-
     if args.theme:
         theme(args.theme)
-
     notify(args.event, sync=False, raise_error=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ streamlit = "^0.69"
 [build-system]
 requires = ["poetry"]
 build-backend = "poetry.masonry.api"
+
+[tool.poetry.scripts]
+chime = "chime:main"

--- a/test_chime.py
+++ b/test_chime.py
@@ -1,3 +1,4 @@
+import subprocess
 import time
 
 import pytest
@@ -20,3 +21,7 @@ def test_no_warning():
 
 def test_no_exception():
     chime.success(sync=True, raise_error=True)
+
+
+def test_script():
+    subprocess.run(["chime"], check=True)


### PR DESCRIPTION
This PR:

- Moves the CLI functionality to the function `main`
- Adds a script under the command `chime`
- Adds a unit test testing the new command
- Updates the command-line sections in the README from `python -m chime` → `chime`

After installing the library, this PR would allow a user to use chime by running

```
% chime
```

in their terminal.

Closes #5 