### PR TITLE
Add the ability to set the default theme through a configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - [Command-line usage](#command-line-usage)
 - [Platform support](#platform-support)
 - [I can't hear anything 🙉](#i-cant-hear-anything-)
+- [Setting a default theme](#setting-a-default-theme)
 - [Adding a new theme](#adding-a-new-theme)
 - [Things to do](#things-to-do)
 - [Acknowledgements](#acknowledgements)
@@ -198,6 +199,18 @@ This will play the sound synchronously and issue a warning if something goes wro
 ```
 
 Note that setting `raise_error` won't do anything if `sync` is set to `False`.
+
+## Setting a default theme
+
+To change the default theme a configuration file may be created in `~/.config/chime/chime.conf` on Unix or `%APPDATA%\chime\chime.ini` on Windows.
+
+For example, to change the default theme to `'zelda'` the configuration file would contain:
+
+```ini
+[chime]
+theme = zelda
+
+```
 
 ## Adding a new theme
 

--- a/chime.py
+++ b/chime.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import pathlib
 import platform
 import random
@@ -17,7 +18,23 @@ except ImportError:
     IPYTHON_INSTALLED = False
 
 
-THEME = 'chime'  # default theme
+def _get_config_path(system: str) -> pathlib.Path:
+    """Return the path of the config file.
+
+    Parameters:
+        system: The OS being used.
+    """
+    home_dir = pathlib.Path.home()
+    if system == "Windows":
+        config_path = (
+            pathlib.Path(
+                         os.getenv('APPDATA',
+                                   home_dir / pathlib.Path("AppData", "Roaming")))
+            / pathlib.Path("chime", "chime.ini")
+        )
+    else:
+        config_path = home_dir / pathlib.Path(".config", "chime", "chime.conf")
+    return config_path.resolve().absolute()
 
 
 __all__ = [

--- a/chime.py
+++ b/chime.py
@@ -26,15 +26,15 @@ def _get_config_path(system: str) -> pathlib.Path:
         system: The OS being used.
     """
     home_dir = pathlib.Path.home()
-    if system == "Windows":
+    if system == 'Windows':
         config_path = (
             pathlib.Path(
                          os.getenv('APPDATA',
-                                   home_dir / pathlib.Path("AppData", "Roaming")))
-            / pathlib.Path("chime", "chime.ini")
+                                   home_dir / pathlib.Path('AppData', 'Roaming')))
+            / pathlib.Path('chime', 'chime.ini')
         )
     else:
-        config_path = home_dir / pathlib.Path(".config", "chime", "chime.conf")
+        config_path = home_dir / pathlib.Path('.config', 'chime', 'chime.conf')
     return config_path.resolve().absolute()
 
 

--- a/chime.py
+++ b/chime.py
@@ -1,4 +1,5 @@
 import argparse
+import configparser
 import os
 import pathlib
 import platform
@@ -35,6 +36,31 @@ def _get_config_path(system: str) -> pathlib.Path:
     else:
         config_path = home_dir / pathlib.Path(".config", "chime", "chime.conf")
     return config_path.resolve().absolute()
+
+
+def _get_default_theme(path: pathlib.Path, fallback_theme: str) -> str:
+    """Check for the existence of a theme in a config file.
+
+    Parameters:
+        path: Path of the config file.
+        fallback_theme: The theme to fallback to if a config file is not found or contains no
+            theme.
+
+    """
+    if path.exists():
+        config = configparser.ConfigParser()
+        config.read(path)
+        if 'chime' in config:
+            default_theme = config['chime'].get('theme', fallback_theme)
+        else:
+            default_theme = fallback_theme
+    else:
+        default_theme = fallback_theme
+    return default_theme
+
+
+config_path = _get_config_path(platform.system())
+THEME = _get_default_theme(config_path, fallback_theme='chime')
 
 
 __all__ = [

--- a/conftest.py
+++ b/conftest.py
@@ -18,4 +18,4 @@ def mock_pathlib_home(monkeypatch: _pytest.monkeypatch.MonkeyPatch):
     with tempfile.TemporaryDirectory() as home_dir:
         home_dir_path = pathlib.Path(home_dir)
         monkeypatch.setattr(pathlib.Path, name='home', value=lambda: home_dir_path)
-        monkeypatch.setenv('APPDATA', value=str(pathlib.Path(home_dir)))
+        monkeypatch.setenv('APPDATA', value=str(home_dir_path))

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,21 @@
+import importlib
+import pathlib
+import tempfile
+
+import _pytest.monkeypatch
+import pytest
+
+import chime
+
+
+@pytest.fixture(scope='function', autouse=True)
+def reload_chime():
+    importlib.reload(chime)
+
+
+@pytest.fixture(scope='function', autouse=True)
+def mock_pathlib_home(monkeypatch: _pytest.monkeypatch.MonkeyPatch):
+    with tempfile.TemporaryDirectory() as home_dir:
+        home_dir_path = pathlib.Path(home_dir)
+        monkeypatch.setattr(pathlib.Path, name='home', value=lambda: home_dir_path)
+        monkeypatch.setenv('APPDATA', value=str(pathlib.Path(home_dir)))

--- a/test_chime.py
+++ b/test_chime.py
@@ -23,6 +23,7 @@ def mock_pathlib_home(monkeypatch: _pytest.monkeypatch.MonkeyPatch):
     with tempfile.TemporaryDirectory() as home_dir:
         home_dir_path = pathlib.Path(home_dir)
         monkeypatch.setattr(pathlib.Path, name='home', value=lambda: home_dir_path)
+        monkeypatch.setenv('APPDATA', value=str(pathlib.Path(home_dir)))
 
 
 def test_speed():

--- a/test_chime.py
+++ b/test_chime.py
@@ -1,4 +1,7 @@
+import pathlib
 import subprocess
+import tempfile
+import textwrap
 import time
 import typing
 
@@ -48,3 +51,14 @@ def test__get_config_path(system: str, expected_config_path: str,
     monkeypatch.setenv('APPDATA', '/Users/chime/AppData/Roaming')
     config_path = chime._get_config_path(system)
     assert config_path.as_posix() == expected_config_path
+
+
+def test__get_default_theme():
+    config_text = textwrap.dedent('''\
+    [chime]
+    theme = zelda
+    ''')
+    with tempfile.NamedTemporaryFile() as chime_config:
+        chime_config.write(config_text.encode())
+        chime._get_default_theme(pathlib.Path(chime_config.name), fallback_theme='chime')
+        assert chime.theme() == 'zelda'

--- a/test_chime.py
+++ b/test_chime.py
@@ -55,16 +55,19 @@ def test_theme_events(theme: str, event: typing.Callable):
 
 
 @pytest.mark.parametrize('system, expected_config_path',
-                         [('Linux', '/Users/chime/.config/chime/chime.conf'),
-                          ('Darwin', '/Users/chime/.config/chime/chime.conf'),
-                          ('Windows', '/Users/chime/AppData/Roaming/chime/chime.ini')])
+                         [('Linux', pathlib.Path('/', 'Users', 'chime', '.config', 'chime',
+                                                 'chime.conf')),
+                          ('Darwin', pathlib.Path('/', 'Users', 'chime', '.config', 'chime',
+                                                  'chime.conf')),
+                          ('Windows', pathlib.Path('/', 'Users', 'chime', 'AppData', 'Roaming',
+                                                   'chime', 'chime.ini'))])
 def test__get_config_path(system: str, expected_config_path: str,
                           monkeypatch: _pytest.monkeypatch.MonkeyPatch):
     monkeypatch.setattr(pathlib.Path, name='home',
                         value=lambda: pathlib.Path('/', 'Users', 'chime'))
     monkeypatch.setenv('APPDATA', '/Users/chime/AppData/Roaming')
     config_path = chime._get_config_path(system)
-    assert config_path.as_posix() == expected_config_path
+    assert config_path == expected_config_path
 
 
 def test__get_default_theme():

--- a/test_chime.py
+++ b/test_chime.py
@@ -2,6 +2,7 @@ import subprocess
 import time
 import typing
 
+import _pytest.monkeypatch
 import pytest
 
 import chime
@@ -35,3 +36,15 @@ def test_script():
 def test_theme_events(theme: str, event: typing.Callable):
     chime.theme(theme)
     assert event(chime) is None
+
+
+@pytest.mark.parametrize('system, expected_config_path',
+                         [('Linux', '/Users/chime/.config/chime/chime.conf'),
+                          ('Darwin', '/Users/chime/.config/chime/chime.conf'),
+                          ('Windows', '/Users/chime/AppData/Roaming/chime/chime.ini')])
+def test__get_config_path(system: str, expected_config_path: str,
+                          monkeypatch: _pytest.monkeypatch.MonkeyPatch):
+    monkeypatch.setenv('HOME', '/Users/chime')
+    monkeypatch.setenv('APPDATA', '/Users/chime/AppData/Roaming')
+    config_path = chime._get_config_path(system)
+    assert config_path.as_posix() == expected_config_path

--- a/test_chime.py
+++ b/test_chime.py
@@ -60,7 +60,8 @@ def test_theme_events(theme: str, event: typing.Callable):
                           ('Windows', '/Users/chime/AppData/Roaming/chime/chime.ini')])
 def test__get_config_path(system: str, expected_config_path: str,
                           monkeypatch: _pytest.monkeypatch.MonkeyPatch):
-    monkeypatch.setenv('HOME', '/Users/chime')
+    monkeypatch.setattr(pathlib.Path, name='home',
+                        value=lambda: pathlib.Path('/', 'Users', 'chime'))
     monkeypatch.setenv('APPDATA', '/Users/chime/AppData/Roaming')
     config_path = chime._get_config_path(system)
     assert config_path.as_posix() == expected_config_path

--- a/test_chime.py
+++ b/test_chime.py
@@ -13,19 +13,6 @@ import pytest
 import chime
 
 
-@pytest.fixture(scope='function', autouse=True)
-def reload_chime():
-    importlib.reload(chime)
-
-
-@pytest.fixture(scope='function', autouse=True)
-def mock_pathlib_home(monkeypatch: _pytest.monkeypatch.MonkeyPatch):
-    with tempfile.TemporaryDirectory() as home_dir:
-        home_dir_path = pathlib.Path(home_dir)
-        monkeypatch.setattr(pathlib.Path, name='home', value=lambda: home_dir_path)
-        monkeypatch.setenv('APPDATA', value=str(pathlib.Path(home_dir)))
-
-
 def test_speed():
     tic = time.time()
     chime.success()

--- a/test_chime.py
+++ b/test_chime.py
@@ -43,11 +43,11 @@ def test_no_exception():
 
 
 def test_script():
-    subprocess.run(["chime"], check=True)
+    subprocess.run(['chime'], check=True)
 
 
-@pytest.mark.parametrize("theme", [theme for theme in chime.themes()])
-@pytest.mark.parametrize("event",
+@pytest.mark.parametrize('theme', [theme for theme in chime.themes()])
+@pytest.mark.parametrize('event',
                          [lambda x: x.error(), lambda x: x.info(), lambda x: x.success(),
                           lambda x: x.warning()])
 def test_theme_events(theme: str, event: typing.Callable):
@@ -73,10 +73,10 @@ def test__get_config_path(system: str, expected_config_path: str,
 
 def test_config_file(monkeypatch: _pytest.monkeypatch.MonkeyPatch):
     assert chime.theme() == 'chime'
-    config_text = textwrap.dedent('''\
+    config_text = textwrap.dedent("""\
     [chime]
     theme = zelda
-    ''')
+    """)
     config_file_dir = pathlib.Path('.config', 'chime')
     monkeypatch.setattr(platform, name='system', value=lambda: 'Linux')
     with tempfile.TemporaryDirectory() as home_dir:

--- a/test_chime.py
+++ b/test_chime.py
@@ -17,6 +17,13 @@ def reload_chime():
     importlib.reload(chime)
 
 
+@pytest.fixture(scope='function', autouse=True)
+def mock_pathlib_home(monkeypatch: _pytest.monkeypatch.MonkeyPatch):
+    with tempfile.TemporaryDirectory() as home_dir:
+        home_dir_path = pathlib.Path(home_dir)
+        monkeypatch.setattr(pathlib.Path, name='home', value=lambda: home_dir_path)
+
+
 def test_speed():
     tic = time.time()
     chime.success()

--- a/test_chime.py
+++ b/test_chime.py
@@ -1,3 +1,4 @@
+import importlib
 import pathlib
 import subprocess
 import tempfile
@@ -9,6 +10,11 @@ import _pytest.monkeypatch
 import pytest
 
 import chime
+
+
+@pytest.fixture(scope='function', autouse=True)
+def reload_chime():
+    importlib.reload(chime)
 
 
 def test_speed():


### PR DESCRIPTION
This PR adds the ability to set the default theme via a configuration file.

The location is set on `~/.config/chime/chime.conf` on Unix or `%APPDATA%\chime\chime.ini` on Windows.

The format of the configuration file is:

```ini
[chime]
theme = zelda

```

Two unit tests have been added that test the detection of the config file location based on platform and test that chime changes its default theme based on the config file.

Closes #13 